### PR TITLE
Fire a google analytics event on form submit

### DIFF
--- a/source/2017-08-22/_future_brochure_signup_form.html.erb
+++ b/source/2017-08-22/_future_brochure_signup_form.html.erb
@@ -1,4 +1,4 @@
-<form id="switch-form" action="https://docs.google.com/a/coopdigital.co.uk/forms/d/e/1FAIpQLScCSd0E_iytFLnrxtPQumpyRqsqo_pZkxrgDeWfu3P_bwP38A/formResponse" method="post">
+<form id="<%= form_id %>" action="https://docs.google.com/a/coopdigital.co.uk/forms/d/e/1FAIpQLScCSd0E_iytFLnrxtPQumpyRqsqo_pZkxrgDeWfu3P_bwP38A/formResponse" method="post">
   <label for="email">Enter your email:</label>
   <input id="email" type="email" name="entry.260833459" value="" required><br />
 

--- a/source/2017-08-22/index.html.erb
+++ b/source/2017-08-22/index.html.erb
@@ -163,7 +163,7 @@ function ready(fn) {
 }
 
 
-function setupClickHandlers() {
+function setupEventHandlers() {
 
   var clickableElements = document.getElementsByClassName('track-clicks');
     for(var i = 0 ; i < clickableElements.length ; ++i) {
@@ -224,7 +224,7 @@ function handleFormSubmit(event) {
 
 }
 
-ready(setupClickHandlers);
+ready(setupEventHandlers);
 
 </script>
 

--- a/source/2017-08-22/index.html.erb
+++ b/source/2017-08-22/index.html.erb
@@ -169,6 +169,11 @@ function setupClickHandlers() {
     for(var i = 0 ; i < clickableElements.length ; ++i) {
       clickableElements[i].addEventListener('click', handleClick);
     }
+
+  var forms = document.getElementsByTagName('form');
+  for(var i = 0 ; i < forms.length ; ++i) {
+    forms[i].addEventListener('submit', handleFormSubmit);
+  }
 }
 
 function handleClick(event) {
@@ -179,6 +184,44 @@ function handleClick(event) {
     eventAction: 'click',
     eventLabel: event.target.id  // good to make the id descriptive
   });
+}
+
+function handleFormSubmit(event) {
+  // this is a bit tricksy, since submitting forms causes the page to unload
+  // and stop javascript running.
+  // See:
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#knowing_when_the_hit_has_been_sent
+
+  var form = event.target,
+      // Keeps track of whether or not the form has been submitted.
+      // This prevents the form from being submitted twice in cases
+      // where `hitCallback` fires normally.
+      formSubmitted = false;
+
+  // Prevents the browser from submitting the form
+  // and thus unloading the current page.
+  event.preventDefault();
+
+  setTimeout(submitForm, 1000);  // in case the GA hit callback never fires
+
+  function submitForm() {
+    if (!formSubmitted) {
+      formSubmitted = true;
+      console.log("calling form.submit()");
+      form.submit();
+    }
+  }
+
+  ga('send', 'event', {
+    eventCategory: 'Sign up form',
+    eventAction: 'form_submit',
+    eventLabel: form.id,
+    hitCallback: function() {
+      console.debug("Got GA event hit callback");
+      submitForm();
+    }
+  });
+
 }
 
 ready(setupClickHandlers);

--- a/source/2017-08-22/index.html.erb
+++ b/source/2017-08-22/index.html.erb
@@ -166,9 +166,9 @@ function ready(fn) {
 function setupEventHandlers() {
 
   var clickableElements = document.getElementsByClassName('track-clicks');
-    for(var i = 0 ; i < clickableElements.length ; ++i) {
-      clickableElements[i].addEventListener('click', handleClick);
-    }
+  for(var i = 0 ; i < clickableElements.length ; ++i) {
+    clickableElements[i].addEventListener('click', handleClick);
+  }
 
   var forms = document.getElementsByTagName('form');
   for(var i = 0 ; i < forms.length ; ++i) {

--- a/source/2017-08-22/index.html.erb
+++ b/source/2017-08-22/index.html.erb
@@ -45,7 +45,7 @@ stylesheet: '2017-08-22'
               <h2>Join us and get back in control</h2>
               <p>Enter your email address to get early access.</p>
               <div class="page-1">
-                <%= partial "future_brochure_signup_form" %>
+                <%= partial("future_brochure_signup_form", :locals => {:form_id => "join-form-1" }) %>
               </div>
             </section>
           </div>
@@ -142,7 +142,7 @@ stylesheet: '2017-08-22'
               <p>If the future seems uncertain, your files are in a mess and you don&rsquo;t know how much is in your pension - you&rsquo;re not alone. Let&rsquo;s start talking about the things that are important to us - and that can be a little uncomfortable - and take control of our futures today.</p>
               <p>Enter your email address to get early access.</p>
               <div class="page-1">
-                <%= partial "future_brochure_signup_form" %>
+                <%= partial("future_brochure_signup_form", :locals => {:form_id => "join-form-2" }) %>
               </div>
             </section>
           </div>

--- a/source/2017-08-22/index.html.erb
+++ b/source/2017-08-22/index.html.erb
@@ -182,7 +182,7 @@ function handleClick(event) {
   ga('send', 'event', {
     eventCategory: 'Find out more',
     eventAction: 'click',
-    eventLabel: event.target.id  // good to make the id descriptive
+    eventLabel: clickedElement.id  // good to make the id descriptive
   });
 }
 


### PR DESCRIPTION
This is a little tricky since the page gets unloaded immediately on form
submit, stopping javascript.

Follow the guidance from Google about (safely) intercepting the form.submit
action:

https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#knowing_when_the_hit_has_been_sent